### PR TITLE
Remove `optional = false` do address em Interview

### DIFF
--- a/src/main/java/com/recrutaibackend/model/Interview.java
+++ b/src/main/java/com/recrutaibackend/model/Interview.java
@@ -44,7 +44,7 @@ public class Interview {
     @Column(name = "reunion_url")
     private String reunionURL;
 
-    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "address_id")
     private Address address;
 


### PR DESCRIPTION
No schema, o campo de endereco esta corretamente definido como nullable, porem na entidade este campo estava como requerido, causando problemas ao tentar criar uma entrevista remota.