### PR TITLE
Corrige integracao entre o H2 e o Spring Security

### DIFF
--- a/src/main/java/com/recrutaibackend/config/SecurityConfiguration.java
+++ b/src/main/java/com/recrutaibackend/config/SecurityConfiguration.java
@@ -6,6 +6,7 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -29,6 +30,8 @@ public class SecurityConfiguration {
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .sessionManagement((config) -> config.sessionCreationPolicy(STATELESS))
+                // Required to H2 console work with Spring Security
+                .headers((config) -> config.frameOptions((HeadersConfigurer.FrameOptionsConfig::disable)))
                 .build();
     }
 


### PR DESCRIPTION
Este commit desabilita o `frameOptions` na configuracao de seguranca que estava causando erro ao acessar o console do H2 no navegador.