### PR TITLE
Corrige integracao entre o H2 e o Docker

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -24,3 +24,5 @@ spring:
   h2:
     console:
       enabled: true
+      settings:
+        web-allow-others: true


### PR DESCRIPTION
O H2 por padrao nao aceita conexoes remotas (de outros "computadores") ao console. Este commit libera este comportamento, para que seja possivel acessar o console quando rodando a aplicacao em um container.